### PR TITLE
Add voice hub plugin and example

### DIFF
--- a/example/lib/Home.dart
+++ b/example/lib/Home.dart
@@ -62,14 +62,22 @@ class _HomeState extends State<Home> {
                     title: Text.rich(
                       TextSpan(children: [TextSpan(text: "Typed Sip Example"), TextSpan(text: "  New", style: TextStyle(color: Colors.green))]),
                     ),
-                    onTap: () {
-                      Navigator.of(context).pushNamed("/typed_sip");
-                    },
+                  onTap: () {
+                    Navigator.of(context).pushNamed("/typed_sip");
+                  },
+                ),
+                ListTile(
+                  title: Text.rich(
+                    TextSpan(children: [TextSpan(text: "Voice Hub Example"), TextSpan(text: "  New", style: TextStyle(color: Colors.green))]),
                   ),
-                ],
-              ),
+                  onTap: () {
+                    Navigator.of(context).pushNamed("/voice_hub");
+                  },
+                ),
+              ],
             ),
           ),
+        ),
         ));
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,6 +6,7 @@ import './typed_examples/sip.dart';
 import './typed_examples/streaming.dart';
 import './typed_examples/video_call.dart';
 import 'typed_examples/text_room.dart';
+import 'typed_examples/voice_hub.dart';
 
 void main() {
   runApp(MaterialApp(
@@ -27,6 +28,7 @@ void main() {
       "/typed_video_call": (c) => TypedVideoCallV2Example(),
       "/typed_audio_bridge": (c) => TypedAudioRoomV2(),
       "/typed_text_room": (c) => TypedTextRoom(),
+      "/voice_hub": (c) => VoiceHubExample(),
       "/": (c) => Home()
     },
   ));

--- a/example/lib/typed_examples/voice_hub.dart
+++ b/example/lib/typed_examples/voice_hub.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:janus_client/janus_client.dart';
+import '../conf.dart';
+
+class VoiceHubExample extends StatefulWidget {
+  @override
+  State<VoiceHubExample> createState() => _VoiceHubExampleState();
+}
+
+class _VoiceHubExampleState extends State<VoiceHubExample> {
+  JanusClient? client;
+  WebSocketJanusTransport? ws;
+  JanusSession? session;
+  JanusVoiceHubPlugin? plugin;
+  MediaStream? _localStream;
+  MediaStream? _remoteStream;
+  RTCVideoRenderer _remoteRenderer = RTCVideoRenderer();
+  bool connected = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _remoteRenderer.initialize();
+  }
+
+  Future<void> connect() async {
+    ws = WebSocketJanusTransport(url: servermap['janus_ws']);
+    client = JanusClient(
+        transport: ws!,
+        iceServers: [RTCIceServer(urls: 'stun:stun.l.google.com:19302')],
+        isUnifiedPlan: true);
+    session = await client!.createSession();
+    plugin = await session!.attach<JanusVoiceHubPlugin>();
+    _localStream = await navigator.mediaDevices
+        .getUserMedia({'audio': true, 'video': false});
+    await plugin!.initializeMediaDevices();
+    plugin!.remoteTrack?.listen((event) {
+      if (event.track != null && event.flowing == true) {
+        _remoteStream ??= MediaStream();
+        _remoteStream!.addTrack(event.track!);
+        _remoteRenderer.srcObject = _remoteStream;
+      }
+    });
+    await plugin!.register('flutter_client');
+    await plugin!.call('server');
+    setState(() {
+      connected = true;
+    });
+  }
+
+  Future<void> disconnect() async {
+    await plugin?.hangup();
+    await session?.dispose();
+    ws?.dispose();
+    await _remoteRenderer.dispose();
+    await _localStream?.dispose();
+    setState(() {
+      connected = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('Voice Hub Example')),
+      body: Column(
+        children: [
+          Expanded(
+              child: RTCVideoView(_remoteRenderer, mirror: false)),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                  onPressed: connected ? null : connect, child: Text('Connect')),
+              SizedBox(width: 20),
+              ElevatedButton(
+                  onPressed: connected ? disconnect : null,
+                  child: Text('Hangup')),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/janus_client.dart
+++ b/lib/janus_client.dart
@@ -42,6 +42,8 @@ part './wrapper_plugins/janus_text_room_plugin.dart';
 
 part './wrapper_plugins/janus_echo_test_plugin.dart';
 
+part './wrapper_plugins/janus_voice_hub_plugin.dart';
+
 part './interfaces/video_room/video_room_list_response.dart';
 
 part './interfaces/video_room/video_room_list_participants_response.dart';

--- a/lib/janus_plugin.dart
+++ b/lib/janus_plugin.dart
@@ -8,6 +8,7 @@ abstract class JanusPlugins {
   static const TEXT_ROOM = "janus.plugin.textroom";
   static const ECHO_TEST = "janus.plugin.echotest";
   static const SIP = "janus.plugin.sip";
+  static const VOICE_HUB = "janus.plugin.voicehub";
 }
 
 class JanusPlugin {

--- a/lib/wrapper_plugins/janus_voice_hub_plugin.dart
+++ b/lib/wrapper_plugins/janus_voice_hub_plugin.dart
@@ -1,0 +1,34 @@
+part of janus_client;
+
+class JanusVoiceHubPlugin extends JanusPlugin {
+  JanusVoiceHubPlugin({handleId, context, transport, session})
+      : super(
+            context: context,
+            handleId: handleId,
+            plugin: JanusPlugins.VOICE_HUB,
+            session: session,
+            transport: transport);
+
+  Future<void> register(String username) async {
+    var payload = {"request": "register", "username": username};
+    await send(data: payload);
+  }
+
+  Future<void> call(String username, {RTCSessionDescription? offer}) async {
+    var payload = {"request": "call", "username": username};
+    offer ??=
+        await createOffer(audioRecv: true, videoRecv: false, dataChannel: true);
+    await send(data: payload, jsep: offer);
+  }
+
+  Future<void> updateSession(Map<String, dynamic> update) async {
+    var data = {"type": "session.update", "session": update};
+    await sendData(stringify(data));
+  }
+
+  @override
+  Future<void> hangup() async {
+    await super.hangup();
+    await send(data: {"request": "hangup"});
+  }
+}


### PR DESCRIPTION
## Summary
- support `janus.plugin.voicehub` in `JanusPlugins`
- include `JanusVoiceHubPlugin` implementation
- add simple Flutter example demonstrating connection and hangup
- wire example into routes and home menu

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852def719208324a4eb6332933f06cd