### PR TITLE
Add voice websocket example

### DIFF
--- a/example/lib/Home.dart
+++ b/example/lib/Home.dart
@@ -66,6 +66,14 @@ class _HomeState extends State<Home> {
                       Navigator.of(context).pushNamed("/typed_sip");
                     },
                   ),
+                  ListTile(
+                    title: Text.rich(
+                      TextSpan(children: [TextSpan(text: "Voice WebSocket"), TextSpan(text: "  New", style: TextStyle(color: Colors.green))]),
+                    ),
+                    onTap: () {
+                      Navigator.of(context).pushNamed("/voice_ws");
+                    },
+                  ),
                 ],
               ),
             ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,6 +6,7 @@ import './typed_examples/sip.dart';
 import './typed_examples/streaming.dart';
 import './typed_examples/video_call.dart';
 import 'typed_examples/text_room.dart';
+import './typed_examples/voice_websocket.dart';
 
 void main() {
   runApp(MaterialApp(
@@ -27,6 +28,7 @@ void main() {
       "/typed_video_call": (c) => TypedVideoCallV2Example(),
       "/typed_audio_bridge": (c) => TypedAudioRoomV2(),
       "/typed_text_room": (c) => TypedTextRoom(),
+      "/voice_ws": (c) => const VoiceWebSocketExample(),
       "/": (c) => Home()
     },
   ));

--- a/example/lib/typed_examples/voice_websocket.dart
+++ b/example/lib/typed_examples/voice_websocket.dart
@@ -1,0 +1,117 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:janus_client/janus_client.dart';
+
+import '../conf.dart';
+
+class VoiceWebSocketExample extends StatefulWidget {
+  const VoiceWebSocketExample({Key? key}) : super(key: key);
+
+  @override
+  State<VoiceWebSocketExample> createState() => _VoiceWebSocketExampleState();
+}
+
+class _VoiceWebSocketExampleState extends State<VoiceWebSocketExample> {
+  JanusClient? _client;
+  WebSocketJanusTransport? _transport;
+  JanusSession? _session;
+  JanusAudioBridgePlugin? _audioHandle;
+
+  RTCVideoRenderer _remoteRenderer = RTCVideoRenderer();
+  MediaStream? _remoteStream;
+  bool _connected = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _remoteRenderer.initialize();
+  }
+
+  Future<void> _connect() async {
+    _transport = WebSocketJanusTransport(url: servermap['janus_ws']);
+    _client = JanusClient(
+      transport: _transport!,
+      isUnifiedPlan: true,
+      iceServers: [
+        RTCIceServer(urls: 'stun:stun.l.google.com:19302'),
+      ],
+    );
+
+    _session = await _client!.createSession();
+    _audioHandle = await _session!.attach<JanusAudioBridgePlugin>();
+
+    await _audioHandle!.initializeMediaDevices(mediaConstraints: {
+      'audio': true,
+      'video': false,
+    });
+
+    _audioHandle!.remoteTrack?.listen((event) async {
+      if (event.track != null && event.flowing == true) {
+        _remoteStream ??= await createLocalMediaStream('remote');
+        await _remoteStream!.addTrack(event.track!);
+        _remoteRenderer.srcObject = _remoteStream;
+        if (kIsWeb) {
+          _remoteRenderer.muted = false;
+        }
+      }
+    });
+
+    await _audioHandle!.joinRoom(1234, display: 'flutter_user');
+
+    setState(() {
+      _connected = true;
+    });
+  }
+
+  Future<void> _hangup() async {
+    await _audioHandle?.hangup();
+    await _audioHandle?.dispose();
+    await _session?.dispose();
+    await _transport?.dispose();
+
+    stopAllTracks(_remoteStream);
+    _remoteRenderer.srcObject = null;
+    _remoteStream = null;
+
+    setState(() {
+      _connected = false;
+    });
+  }
+
+  @override
+  void dispose() {
+    _hangup();
+    _remoteRenderer.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Voice WebSocket'),
+      ),
+      body: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Expanded(child: RTCVideoView(_remoteRenderer)),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(
+                onPressed: _connected ? null : _connect,
+                child: const Text('Connect'),
+              ),
+              const SizedBox(width: 20),
+              ElevatedButton(
+                onPressed: _connected ? _hangup : null,
+                child: const Text('Hangup'),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a new `VoiceWebSocketExample` in example project to demonstrate connecting and closing WebRTC using Janus over WebSocket
- wire the new example into the menu and routes

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852def719208324a4eb6332933f06cd