### PR TITLE
Add simple voice hub plugin and example

### DIFF
--- a/example/lib/Home.dart
+++ b/example/lib/Home.dart
@@ -44,6 +44,14 @@ class _HomeState extends State<Home> {
                   ),
                   ListTile(
                     title: Text.rich(
+                      TextSpan(children: [TextSpan(text: "Voice Hub"), TextSpan(text: "  New", style: TextStyle(color: Colors.green))]),
+                    ),
+                    onTap: () {
+                      Navigator.of(context).pushNamed("/voice_hub");
+                    },
+                  ),
+                  ListTile(
+                    title: Text.rich(
                       TextSpan(children: [TextSpan(text: "Typed Audio Bridge Unified"), TextSpan(text: "  New", style: TextStyle(color: Colors.green))]),
                     ),
                     onTap: () {

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,6 +5,7 @@ import './typed_examples/google_meet.dart';
 import './typed_examples/sip.dart';
 import './typed_examples/streaming.dart';
 import './typed_examples/video_call.dart';
+import './typed_examples/voice_hub.dart';
 import 'typed_examples/text_room.dart';
 
 void main() {
@@ -25,6 +26,7 @@ void main() {
       "/typed_sip": (c) => TypedSipExample(),
       "/typed_streaming": (c) => TypedStreamingV2(),
       "/typed_video_call": (c) => TypedVideoCallV2Example(),
+      "/voice_hub": (c) => VoiceHubExample(),
       "/typed_audio_bridge": (c) => TypedAudioRoomV2(),
       "/typed_text_room": (c) => TypedTextRoom(),
       "/": (c) => Home()

--- a/example/lib/typed_examples/voice_hub.dart
+++ b/example/lib/typed_examples/voice_hub.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:janus_client/janus_client.dart';
+import '../conf.dart';
+
+class VoiceHubExample extends StatefulWidget {
+  @override
+  State<VoiceHubExample> createState() => _VoiceHubExampleState();
+}
+
+class _VoiceHubExampleState extends State<VoiceHubExample> {
+  late JanusClient client;
+  late WebSocketJanusTransport ws;
+  JanusSession? session;
+  JanusVoiceHubPlugin? plugin;
+  RTCVideoRenderer _remoteRenderer = RTCVideoRenderer();
+  RTCVideoRenderer _localRenderer = RTCVideoRenderer();
+  TextEditingController nameController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _initRenderers();
+    _initClient();
+  }
+
+  Future<void> _initRenderers() async {
+    await _remoteRenderer.initialize();
+    await _localRenderer.initialize();
+  }
+
+  Future<void> _initClient() async {
+    ws = WebSocketJanusTransport(url: servermap['janus_ws']);
+    client = JanusClient(
+        transport: ws,
+        iceServers: [
+          RTCIceServer(urls: 'stun:stun.l.google.com:19302')
+        ],
+        isUnifiedPlan: true);
+    session = await client.createSession();
+    plugin = await session!.attach<JanusVoiceHubPlugin>();
+    plugin!.remoteTrack?.listen((event) async {
+      if (event.track != null && event.flowing == true) {
+        MediaStream stream = await createLocalMediaStream(event.track!.id!);
+        await stream.addTrack(event.track!);
+        _remoteRenderer.srcObject = stream;
+        if (kIsWeb) _remoteRenderer.muted = false;
+      }
+    });
+  }
+
+  Future<void> startCall() async {
+    await plugin!.initializeMediaDevices(mediaConstraints: {'audio': true});
+    _localRenderer.srcObject = plugin!.webRTCHandle?.localStream;
+    await plugin!.register(nameController.text.isEmpty ? 'flutter_client' : nameController.text);
+    var offer = await plugin!.createOffer(audioRecv: true, videoRecv: false);
+    await plugin!.call(nameController.text.isEmpty ? 'flutter_client' : nameController.text, offer: offer);
+  }
+
+  Future<void> hangup() async {
+    await plugin?.hangup();
+    await session?.dispose();
+  }
+
+  @override
+  void dispose() {
+    _localRenderer.dispose();
+    _remoteRenderer.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Voice Hub')),
+      body: Column(
+        children: [
+          Expanded(
+            child: RTCVideoView(_remoteRenderer, mirror: true),
+          ),
+          const SizedBox(height: 16),
+          TextField(
+            controller: nameController,
+            decoration: const InputDecoration(labelText: 'Name'),
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              ElevatedButton(onPressed: startCall, child: const Text('Start')),
+              const SizedBox(width: 12),
+              ElevatedButton(onPressed: hangup, child: const Text('Hangup')),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/janus_client.dart
+++ b/lib/janus_client.dart
@@ -27,6 +27,7 @@ part 'janus_plugin.dart';
 part './utils.dart';
 
 part './wrapper_plugins/janus_video_call_plugin.dart';
+part './wrapper_plugins/janus_voice_hub_plugin.dart';
 
 part './wrapper_plugins/janus_sip_plugin.dart';
 

--- a/lib/janus_plugin.dart
+++ b/lib/janus_plugin.dart
@@ -5,6 +5,7 @@ abstract class JanusPlugins {
   static const AUDIO_BRIDGE = "janus.plugin.audiobridge";
   static const STREAMING = "janus.plugin.streaming";
   static const VIDEO_CALL = "janus.plugin.videocall";
+  static const VOICE_HUB = "janus.plugin.voicehub";
   static const TEXT_ROOM = "janus.plugin.textroom";
   static const ECHO_TEST = "janus.plugin.echotest";
   static const SIP = "janus.plugin.sip";

--- a/lib/wrapper_plugins/janus_voice_hub_plugin.dart
+++ b/lib/wrapper_plugins/janus_voice_hub_plugin.dart
@@ -1,0 +1,33 @@
+part of janus_client;
+
+class JanusVoiceHubPlugin extends JanusPlugin {
+  JanusVoiceHubPlugin({handleId, context, transport, session})
+      : super(
+            context: context,
+            handleId: handleId,
+            plugin: JanusPlugins.VOICE_HUB,
+            session: session,
+            transport: transport);
+
+  Future<void> register(String userName) async {
+    await send(data: {"request": "register", "username": userName});
+  }
+
+  Future<void> call(String userName, {RTCSessionDescription? offer}) async {
+    if (offer == null) {
+      offer = await createOffer(audioRecv: true, videoRecv: false);
+    }
+    await send(data: {"request": "call", "username": userName}, jsep: offer);
+  }
+
+  Future<void> updateSession(Map<String, dynamic> session) async {
+    await send(data: {"type": "session.update", "session": session});
+  }
+
+  @override
+  Future<void> hangup() async {
+    await super.hangup();
+    await send(data: {"request": "hangup"});
+    dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- add VOICE_HUB plugin type
- create `JanusVoiceHubPlugin`
- expose plugin in janus client
- add minimal example demonstrating start/hangup of a voice session
- add new menu entry for voice hub in example app

## Testing
- `apt-get update`
- `apt-get install -y dart` *(failed: Unable to locate package)*
- `dart format -o none --set-exit-if-changed .` *(failed: dart command not found)*
- `flutter analyze --no-pub` *(failed: flutter command not found)*
- `flutter test` *(failed: flutter command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852def719208324a4eb6332933f06cd