### PR TITLE
Add voice hub example

### DIFF
--- a/example/lib/conf.dart
+++ b/example/lib/conf.dart
@@ -1,5 +1,12 @@
 Map<String, String> servermap = {
   'janus_ws': 'wss://janus1.januscaler.com/janus/ws',
   'janus_rest': 'https://janus.conf.meetecho.com/janus',
-  'servercheap': 'ws://107.152.35.248:8188'
+  'servercheap': 'ws://107.152.35.248:8188',
+  // Base URL for backend REST APIs used by the voice hub example.
+  // Replace with your own service endpoint.
+  'api_base': 'https://example.com',
+  // WebSocket endpoint for lifecycle signalling.
+  'api_ws': 'wss://example.com',
+  // Example assistant id used with the voice hub service.
+  'assistant_id': '1'
 };

--- a/example/lib/typed_examples/voice_hub_example.dart
+++ b/example/lib/typed_examples/voice_hub_example.dart
@@ -1,0 +1,149 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:dio/dio.dart';
+import 'package:janus_client/janus_client.dart';
+import 'package:uuid/uuid.dart';
+import '../conf.dart';
+
+class VoiceHubExample extends StatefulWidget {
+  const VoiceHubExample({super.key});
+
+  @override
+  State<VoiceHubExample> createState() => _VoiceHubExampleState();
+}
+
+class _VoiceHubExampleState extends State<VoiceHubExample> {
+  JanusClient? _client;
+  JanusSession? _session;
+  JanusVoiceHubPlugin? _plugin;
+  WebSocketJanusTransport? _transport;
+  WebSocket? _lifecycleWs;
+  final Dio _dio = Dio();
+
+  MediaStream? _localStream;
+  MediaStream? _remoteStream;
+  RTCVideoRenderer _remoteRenderer = RTCVideoRenderer();
+  bool _inCall = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _remoteRenderer.initialize();
+  }
+
+  Future<void> _start() async {
+    // Step 1: request conversation details from backend.
+    final conv = await _dio.post('${servermap['api_base']}/ai_create_conversation');
+    final convData = conv.data['data'];
+    final userId = convData['user_id'];
+    final threadId = convData['thread_id'];
+
+    // Step 2: obtain STUN/TURN servers from backend.
+    final iceRes = await _dio.get('${servermap['api_base']}/ai_ice_servers');
+    final iceList = List<Map<String, dynamic>>.from(iceRes.data['data']);
+    final iceServers = iceList
+        .map((e) => RTCIceServer(
+            urls: e['urls'],
+            username: e['username'],
+            credential: e['credential']))
+        .toList();
+
+    // Step 3: create Janus session and attach plugin.
+    _transport = WebSocketJanusTransport(url: servermap['janus_ws']);
+    _client = JanusClient(
+      transport: _transport!,
+      isUnifiedPlan: true,
+      iceServers: iceServers,
+    );
+    _session = await _client!.createSession();
+    _plugin = await _session!.attach<JanusVoiceHubPlugin>();
+
+    await _plugin!.initializeMediaDevices(mediaConstraints: {
+      'audio': true,
+      'video': false,
+    });
+    _localStream = _plugin!.webRTCHandle?.localStream;
+    _plugin!.remoteTrack?.listen((event) async {
+      if (event.track != null && event.flowing == true) {
+        _remoteStream ??= await createLocalMediaStream('remote');
+        _remoteStream!.addTrack(event.track!);
+        _remoteRenderer.srcObject = _remoteStream;
+        setState(() {});
+      }
+    });
+
+    // Step 4: open lifecycle WebSocket.
+    final wsUrl =
+        '${servermap['api_ws']}/realtime/webrtc_lifecycle?user_id=$userId&assistant_id=${servermap['assistant_id']}&thread_id=$threadId';
+    _lifecycleWs = await WebSocket.connect(wsUrl);
+    _lifecycleWs!.listen(_onWsMessage, onDone: _stop);
+
+    // Step 5: register and start call on the voice hub plugin.
+    String user = const Uuid().v4();
+    await _plugin!.register(user);
+    var offer = await _plugin!.createOffer(audioRecv: true, videoRecv: false);
+    await _plugin!.call(user, offer: offer);
+    setState(() => _inCall = true);
+  }
+
+  void _onWsMessage(dynamic data) async {
+    final msg = jsonDecode(data as String);
+    final type = msg['type'];
+    final options = msg['options'];
+    if (type == 'message' && options == 2 && msg['ready'] == true) {
+      await _plugin?.sendSessionUpdate({
+        'instructions': 'hello from flutter',
+        'voice': 'alloy',
+        'input_audio_transcription': null,
+      });
+    }
+    if (type == 'hangup') {
+      _stop();
+    }
+  }
+
+  Future<void> _stop() async {
+    await _plugin?.hangup();
+    await _session?.dispose();
+    await _transport?.dispose();
+    await _lifecycleWs?.close();
+    await _remoteRenderer.dispose();
+    setState(() {
+      _inCall = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Voice Hub Example')),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _inCall ? null : _start,
+              child: const Text('Connect'),
+            ),
+            const SizedBox(height: 10),
+            ElevatedButton(
+              onPressed: _inCall ? _stop : null,
+              child: const Text('Hangup'),
+            ),
+            const SizedBox(height: 20),
+            Expanded(
+              child: RTCVideoView(
+                _remoteRenderer,
+                objectFit: RTCVideoViewObjectFit.RTCVideoViewObjectFitContain,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/janus_client.dart
+++ b/lib/janus_client.dart
@@ -42,6 +42,8 @@ part './wrapper_plugins/janus_text_room_plugin.dart';
 
 part './wrapper_plugins/janus_echo_test_plugin.dart';
 
+part './wrapper_plugins/janus_voice_hub_plugin.dart';
+
 part './interfaces/video_room/video_room_list_response.dart';
 
 part './interfaces/video_room/video_room_list_participants_response.dart';

--- a/lib/janus_plugin.dart
+++ b/lib/janus_plugin.dart
@@ -8,6 +8,7 @@ abstract class JanusPlugins {
   static const TEXT_ROOM = "janus.plugin.textroom";
   static const ECHO_TEST = "janus.plugin.echotest";
   static const SIP = "janus.plugin.sip";
+  static const VOICE_HUB = "janus.plugin.voicehub";
 }
 
 class JanusPlugin {

--- a/lib/janus_session.dart
+++ b/lib/janus_session.dart
@@ -75,6 +75,8 @@ class JanusSession {
       plugin = JanusEchoTestPlugin(transport: _transport, context: _context, handleId: handleId, session: this);
     } else if (T == JanusSipPlugin) {
       plugin = JanusSipPlugin(transport: _transport, context: _context, handleId: handleId, session: this);
+    } else if (T == JanusVoiceHubPlugin) {
+      plugin = JanusVoiceHubPlugin(transport: _transport, context: _context, handleId: handleId, session: this);
     } else {
       throw UnimplementedError('''This Plugin is not defined kindly refer to Janus Server Docs
       make sure you specify the type of plugin you want to attach like session.attach<JanusVideoRoomPlugin>();

--- a/lib/wrapper_plugins/janus_voice_hub_plugin.dart
+++ b/lib/wrapper_plugins/janus_voice_hub_plugin.dart
@@ -1,0 +1,38 @@
+part of janus_client;
+
+/// Minimal wrapper for a hypothetical Janus voice hub plugin.
+/// This exposes basic registration and call methods
+/// and allows closing the connection properly.
+class JanusVoiceHubPlugin extends JanusPlugin {
+  JanusVoiceHubPlugin({handleId, context, transport, session})
+      : super(
+            context: context,
+            handleId: handleId,
+            plugin: JanusPlugins.VOICE_HUB,
+            session: session,
+            transport: transport);
+
+  /// Register a user on the voice hub plugin
+  Future<void> register(String username) async {
+    await send(data: {"request": "register", "username": username});
+  }
+
+  /// Start a call with [username].
+  /// If [offer] is not supplied a default audio offer will be generated.
+  Future<void> call(String username, {RTCSessionDescription? offer}) async {
+    offer ??= await createOffer(audioRecv: true, videoRecv: false);
+    await send(data: {"request": "call", "username": username}, jsep: offer);
+  }
+
+  /// Send a session update payload on the data channel.
+  Future<void> sendSessionUpdate(Map<String, dynamic> session) async {
+    await sendData(jsonEncode({"type": "session.update", "session": session}));
+  }
+
+  /// Hangup the call and clean resources.
+  Future<void> hangup() async {
+    await super.hangup();
+    await send(data: {"request": "hangup"});
+    dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `JanusVoiceHubPlugin` for connecting to a voice hub plugin
- expose plugin in `JanusClient` and allow attaching it via session
- add demo `voice_hub_example.dart` showing WebSocket voice call connection
- integrate dio in the example to fetch REST data before starting WebRTC

## Testing
- `flutter test test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852def719208324a4eb6332933f06cd