### PR TITLE
Add voice hub example

### DIFF
--- a/example/lib/conf.dart
+++ b/example/lib/conf.dart
@@ -1,5 +1,9 @@
 Map<String, String> servermap = {
   'janus_ws': 'wss://janus1.januscaler.com/janus/ws',
   'janus_rest': 'https://janus.conf.meetecho.com/janus',
-  'servercheap': 'ws://107.152.35.248:8188'
+  'servercheap': 'ws://107.152.35.248:8188',
+  // Base http endpoint used for fetching ICE servers and conversations
+  'backend': 'https://example.com',
+  // WebSocket base used for lifecycle events similar to the Vue app
+  'socket': 'wss://example.com'
 };

--- a/example/lib/typed_examples/voice_hub_example.dart
+++ b/example/lib/typed_examples/voice_hub_example.dart
@@ -1,0 +1,132 @@
+import 'dart:async';
+import 'dart:io';
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_webrtc/flutter_webrtc.dart';
+import 'package:janus_client/janus_client.dart';
+import 'package:uuid/uuid.dart';
+import '../conf.dart';
+
+class VoiceHubExample extends StatefulWidget {
+  const VoiceHubExample({super.key});
+
+  @override
+  State<VoiceHubExample> createState() => _VoiceHubExampleState();
+}
+
+class _VoiceHubExampleState extends State<VoiceHubExample> {
+  JanusClient? _client;
+  JanusSession? _session;
+  JanusVoiceHubPlugin? _plugin;
+  WebSocketJanusTransport? _transport;
+  final Dio _dio = Dio();
+  WebSocket? _lifecycleSocket;
+
+  MediaStream? _localStream;
+  MediaStream? _remoteStream;
+  RTCVideoRenderer _remoteRenderer = RTCVideoRenderer();
+  bool _inCall = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _remoteRenderer.initialize();
+  }
+
+  Future<void> _start() async {
+    try {
+      final conv = await _dio.post('${servermap['backend']}/ai_create_conversation');
+      final data = conv.data['data'];
+      final userId = data['user_id'];
+      final threadId = data['thread_id'];
+
+      final iceRes = await _dio.get('${servermap['backend']}/ai_ice_servers');
+      final serverList = (iceRes.data['data'] as List?) ?? [];
+      final ice = serverList
+          .map<RTCIceServer>((e) => RTCIceServer(
+                urls: e['urls'],
+                username: e['username'],
+                credential: e['credential'],
+              ))
+          .toList();
+
+      _lifecycleSocket = await WebSocket.connect(
+          '${servermap['socket']}/realtime/webrtc_lifecycle?user_id=$userId&assistant_id=demo&thread_id=$threadId');
+
+      _transport = WebSocketJanusTransport(url: servermap['janus_ws']);
+      _client = JanusClient(
+        transport: _transport!,
+        isUnifiedPlan: true,
+        iceServers: ice.isNotEmpty
+            ? ice
+            : [RTCIceServer(urls: 'stun:stun.l.google.com:19302')],
+      );
+      _session = await _client!.createSession();
+      _plugin = await _session!.attach<JanusVoiceHubPlugin>();
+      await _plugin!.initializeMediaDevices(mediaConstraints: {
+        'audio': true,
+        'video': false,
+      });
+      _localStream = _plugin!.webRTCHandle?.localStream;
+      _plugin!.remoteTrack?.listen((event) async {
+        if (event.track != null && event.flowing == true) {
+          _remoteStream ??= await createLocalMediaStream('remote');
+          _remoteStream!.addTrack(event.track!);
+          _remoteRenderer.srcObject = _remoteStream;
+          setState(() {});
+        }
+      });
+      String user = const Uuid().v4();
+      await _plugin!.register(user);
+      var offer = await _plugin!.createOffer(audioRecv: true, videoRecv: false);
+      await _plugin!.call(user, offer: offer);
+      setState(() {
+        _inCall = true;
+      });
+    } catch (e) {
+      debugPrint('error starting voice hub: $e');
+    }
+  }
+
+  Future<void> _stop() async {
+    await _plugin?.hangup();
+    await _session?.dispose();
+    await _transport?.dispose();
+    await _lifecycleSocket?.close();
+    await _remoteRenderer.dispose();
+    setState(() {
+      _inCall = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Voice Hub Example')),
+      body: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: _inCall ? null : _start,
+              child: const Text('Connect'),
+            ),
+            const SizedBox(height: 10),
+            ElevatedButton(
+              onPressed: _inCall ? _stop : null,
+              child: const Text('Hangup'),
+            ),
+            const SizedBox(height: 20),
+            Expanded(
+              child: RTCVideoView(
+                _remoteRenderer,
+                objectFit: RTCVideoViewObjectFit.RTCVideoViewObjectFitContain,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   prompt_dialog: ^1.0.9
   flutter_foreground_task: ^3.10.0
   permission_handler: ^10.4.3
+  dio: ^5.4.0
 
 
 

--- a/lib/janus_client.dart
+++ b/lib/janus_client.dart
@@ -42,6 +42,8 @@ part './wrapper_plugins/janus_text_room_plugin.dart';
 
 part './wrapper_plugins/janus_echo_test_plugin.dart';
 
+part './wrapper_plugins/janus_voice_hub_plugin.dart';
+
 part './interfaces/video_room/video_room_list_response.dart';
 
 part './interfaces/video_room/video_room_list_participants_response.dart';

--- a/lib/janus_plugin.dart
+++ b/lib/janus_plugin.dart
@@ -8,6 +8,7 @@ abstract class JanusPlugins {
   static const TEXT_ROOM = "janus.plugin.textroom";
   static const ECHO_TEST = "janus.plugin.echotest";
   static const SIP = "janus.plugin.sip";
+  static const VOICE_HUB = "janus.plugin.voicehub";
 }
 
 class JanusPlugin {

--- a/lib/janus_session.dart
+++ b/lib/janus_session.dart
@@ -75,6 +75,8 @@ class JanusSession {
       plugin = JanusEchoTestPlugin(transport: _transport, context: _context, handleId: handleId, session: this);
     } else if (T == JanusSipPlugin) {
       plugin = JanusSipPlugin(transport: _transport, context: _context, handleId: handleId, session: this);
+    } else if (T == JanusVoiceHubPlugin) {
+      plugin = JanusVoiceHubPlugin(transport: _transport, context: _context, handleId: handleId, session: this);
     } else {
       throw UnimplementedError('''This Plugin is not defined kindly refer to Janus Server Docs
       make sure you specify the type of plugin you want to attach like session.attach<JanusVideoRoomPlugin>();

--- a/lib/wrapper_plugins/janus_voice_hub_plugin.dart
+++ b/lib/wrapper_plugins/janus_voice_hub_plugin.dart
@@ -1,0 +1,38 @@
+part of janus_client;
+
+/// Minimal wrapper for a hypothetical Janus voice hub plugin.
+/// This exposes basic registration and call methods
+/// and allows closing the connection properly.
+class JanusVoiceHubPlugin extends JanusPlugin {
+  JanusVoiceHubPlugin({handleId, context, transport, session})
+      : super(
+            context: context,
+            handleId: handleId,
+            plugin: JanusPlugins.VOICE_HUB,
+            session: session,
+            transport: transport);
+
+  /// Register a user on the voice hub plugin
+  Future<void> register(String username) async {
+    await send(data: {"request": "register", "username": username});
+  }
+
+  /// Start a call with [username].
+  /// If [offer] is not supplied a default audio offer will be generated.
+  Future<void> call(String username, {RTCSessionDescription? offer}) async {
+    offer ??= await createOffer(audioRecv: true, videoRecv: false);
+    await send(data: {"request": "call", "username": username}, jsep: offer);
+  }
+
+  /// Send a session update payload on the data channel.
+  Future<void> sendSessionUpdate(Map<String, dynamic> session) async {
+    await sendData(jsonEncode({"type": "session.update", "session": session}));
+  }
+
+  /// Hangup the call and clean resources.
+  Future<void> hangup() async {
+    await super.hangup();
+    await send(data: {"request": "hangup"});
+    dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- introduce `JanusVoiceHubPlugin` for connecting to a voice hub plugin
- expose plugin in `JanusClient` and allow attaching it via session
- add demo `voice_hub_example.dart` showing WebSocket voice call connection
- use Dio in the example to fetch ICE servers and conversation info

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852def719208324a4eb6332933f06cd